### PR TITLE
Update/increase illuminate contracts version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^10.0",
         "lorisleiva/laravel-actions": "^2.4",
         "spatie/laravel-package-tools": "^1.13.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^8.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",


### PR DESCRIPTION
This PR updates `illuminate/contracts` to version ^10 and `orchestra/testbench` so this package is compatible with Laravel 10.